### PR TITLE
Optimize CodeQL workflow

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,72 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - ".github/workflows/**"
+      - "Package.swift"
+      - "Package.resolved"
+      - "Resources/**"
+      - "Scripts/**"
+      - "Sources/**"
+      - "Tests/**"
+  pull_request:
+    branches: [main]
+    paths:
+      - ".github/workflows/**"
+      - "Package.swift"
+      - "Package.resolved"
+      - "Resources/**"
+      - "Scripts/**"
+      - "Sources/**"
+      - "Tests/**"
+  schedule:
+    - cron: "23 4 * * 1"
+  workflow_dispatch:
+
+permissions:
+  actions: read
+  contents: read
+  packages: read
+  security-events: write
+
+concurrency:
+  group: codeql-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - language: actions
+            build-mode: none
+            os: ubuntu-latest
+          - language: swift
+            build-mode: manual
+            os: macos-15
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: ${{ matrix.build-mode }}
+          queries: security-extended
+
+      - name: Build Swift
+        if: matrix.language == 'swift'
+        run: swift build --arch arm64
+
+      - name: Analyze
+        uses: github/codeql-action/analyze@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4
+        with:
+          category: /language:${{ matrix.language }}


### PR DESCRIPTION
## Summary

- add an Advanced Setup workflow for CodeQL
- run CodeQL on source, tests, build files, resources, scripts, and workflow changes
- keep a weekly scan and allow manual runs
- use an explicit arm64 Swift build instead of the heuristic autobuilder
- stop runs after 30 minutes
- pin all third-party actions to immutable commits

## Why

CodeQL Default Setup runs a full Swift autobuild for every pull request, including documentation-only changes. Recent Swift scans in this repository took about 14–22 minutes, while the normal test job finished in under a minute.

After the cutover, README, documentation, image, and license-only changes will not start CodeQL. Code and workflow changes will still be scanned, and the weekly scan remains in place.

The repository is public, so standard GitHub-hosted runners are currently free. This change reduces wasted runner time and pull request latency rather than fixing a current bill.

## Checks

- parsed `.github/workflows/codeql.yml` as YAML
- `git diff --check`
- ran the manual Swift build through full Xcode: `swift build --arch arm64`
- switched the repository from Default Setup to Advanced Setup
- verified `Analyze (actions)` in 33 seconds
- verified `Analyze (swift)` in 12 minutes 56 seconds
- verified the existing Swift test job in 49 seconds
