### PR TITLE
Keep limits available when usage history fails

### DIFF
--- a/Resources/Info.plist
+++ b/Resources/Info.plist
@@ -13,9 +13,9 @@
     <key>CFBundlePackageType</key>
     <string>APPL</string>
     <key>CFBundleShortVersionString</key>
-    <string>0.2.0</string>
+    <string>0.2.1</string>
     <key>CFBundleVersion</key>
-    <string>2</string>
+    <string>3</string>
     <key>LSApplicationCategoryType</key>
     <string>public.app-category.developer-tools</string>
     <key>LSMinimumSystemVersion</key>

--- a/Sources/CodexLimits/CodexClient.swift
+++ b/Sources/CodexLimits/CodexClient.swift
@@ -1,25 +1,5 @@
 import Foundation
 
-enum CodexClientError: LocalizedError {
-    case cliNotFound
-    case invalidResponse
-    case mainLimitMissing
-    case timedOut
-
-    var errorDescription: String? {
-        switch self {
-        case .cliNotFound:
-            "Codex CLI was not found. Install it with Homebrew, sign in, and try again."
-        case .invalidResponse:
-            "Codex returned data this app could not read. Update Codex CLI and try again."
-        case .mainLimitMissing:
-            "Codex did not return a usable limit. Make sure Codex CLI is signed in."
-        case .timedOut:
-            "Codex took too long to respond. Try refreshing again."
-        }
-    }
-}
-
 enum CodexClient {
     private static let executablePaths = [
         "/opt/homebrew/bin/codex",
@@ -80,13 +60,27 @@ enum CodexClient {
 
     static func decode(
         rateLimitsResponse: Data,
-        usageResponse: Data,
+        usageResponse: Data?,
         fetchedAt: Date
     ) throws -> UsageSnapshot {
         let decoder = JSONDecoder()
-        guard let rateResult = try decoder.decode(RPCResponse<RateLimitsResult>.self, from: rateLimitsResponse).result,
-              let usageResult = try decoder.decode(RPCResponse<UsageResult>.self, from: usageResponse).result else {
+        guard let rateResult = try decoder.decode(
+            RPCResponse<RateLimitsResult>.self,
+            from: rateLimitsResponse
+        ).result else {
             throw CodexClientError.invalidResponse
+        }
+        let usageResult: UsageResult?
+        if let usageResponse {
+            guard let result = try decoder.decode(
+                RPCResponse<UsageResult>.self,
+                from: usageResponse
+            ).result else {
+                throw CodexClientError.invalidResponse
+            }
+            usageResult = result
+        } else {
+            usageResult = nil
         }
 
         let snapshots = rateResult.rateLimitsByLimitId ?? ["codex": rateResult.rateLimits]
@@ -123,7 +117,7 @@ enum CodexClient {
         dateFormatter.calendar = Calendar(identifier: .gregorian)
         dateFormatter.timeZone = TimeZone(secondsFromGMT: 0)
         dateFormatter.dateFormat = "yyyy-MM-dd"
-        let tokenHistory = (usageResult.dailyUsageBuckets ?? []).compactMap { bucket -> TokenDay? in
+        let tokenHistory = (usageResult?.dailyUsageBuckets ?? []).compactMap { bucket -> TokenDay? in
             guard let date = dateFormatter.date(from: bucket.startDate) else { return nil }
             return TokenDay(date: date, tokens: bucket.tokens)
         }
@@ -160,35 +154,54 @@ enum CodexClient {
         try handle.write(contentsOf: Data((message + "\n").utf8))
     }
 
-    private static func readSnapshot(
+    static func readSnapshot(
         from output: FileHandle,
         writingTo input: FileHandle,
         fetchedAt: Date
     ) async throws -> UsageSnapshot {
         var rateLimitsResponse: Data?
         var usageResponse: Data?
+        var usageRequestFinished = false
 
         for try await line in output.bytes.lines {
             try Task.checkCancellation()
             let data = Data(line.utf8)
             guard let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
-                  let id = object["id"] as? Int else { continue }
+                  let rawID = object["id"] as? Int,
+                  let id = RequestID(rawValue: rawID) else { continue }
 
-            if object["error"] != nil { throw CodexClientError.invalidResponse }
-            switch id {
-            case 1:
-                try write(#"{"method":"initialized"}"#, to: input)
-                try write(#"{"id":2,"method":"account/rateLimits/read"}"#, to: input)
-                try write(#"{"id":3,"method":"account/usage/read"}"#, to: input)
-            case 2:
-                rateLimitsResponse = data
-            case 3:
-                usageResponse = data
-            default:
-                continue
+            if object["error"] != nil {
+                switch id {
+                case .rateLimits:
+                    throw CodexClientError.invalidResponse
+                case .usage:
+                    usageRequestFinished = true
+                default:
+                    continue
+                }
             }
 
-            if let rateLimitsResponse, let usageResponse {
+            switch id {
+            case .initialize:
+                try write(#"{"method":"initialized"}"#, to: input)
+                try write(
+                    #"{"id":\#(RequestID.rateLimits.rawValue),"method":"account/rateLimits/read"}"#,
+                    to: input
+                )
+                try write(
+                    #"{"id":\#(RequestID.usage.rawValue),"method":"account/usage/read"}"#,
+                    to: input
+                )
+            case .rateLimits:
+                rateLimitsResponse = data
+            case .usage:
+                if object["error"] == nil {
+                    usageResponse = data
+                    usageRequestFinished = true
+                }
+            }
+
+            if let rateLimitsResponse, usageRequestFinished {
                 return try decode(
                     rateLimitsResponse: rateLimitsResponse,
                     usageResponse: usageResponse,
@@ -198,6 +211,12 @@ enum CodexClient {
         }
         throw CodexClientError.invalidResponse
     }
+}
+
+private enum RequestID: Int {
+    case initialize = 1
+    case rateLimits = 2
+    case usage = 3
 }
 
 private struct RPCResponse<Result: Decodable>: Decodable {

--- a/Sources/CodexLimits/CodexClient.swift
+++ b/Sources/CodexLimits/CodexClient.swift
@@ -443,13 +443,13 @@ actor CodexClient {
             from: connection
         ).values[initializeID]
         guard let response,
-              let object = try JSONSerialization.jsonObject(
-                with: response
-              ) as? [String: Any],
-              object["error"] == nil else {
+              let result = try? JSONDecoder().decode(
+                  RPCResponse<InitializeResult>.self,
+                  from: response
+              ).result else {
             throw CodexClientError.invalidResponse
         }
-        serverCLIVersion = Self.serverCLIVersion(in: object)
+        serverCLIVersion = Self.serverCLIVersion(in: result.userAgent)
         try Self.write(#"{"method":"initialized"}"#, to: connection.input)
         initialized = true
     }
@@ -491,12 +491,9 @@ actor CodexClient {
     }
 
     private static func serverCLIVersion(
-        in response: [String: Any]
+        in userAgent: String?
     ) -> String? {
-        guard let result = response["result"] as? [String: Any],
-              let userAgent = result["userAgent"] as? String else {
-            return nil
-        }
+        guard let userAgent else { return nil }
         return userAgent.split(separator: " ").compactMap { component in
             let parts = component.split(separator: "/", maxSplits: 1)
             guard parts.count == 2,
@@ -750,10 +747,16 @@ actor CodexClient {
         fetchedAt: Date
     ) throws -> UsageSnapshot {
         let decoder = JSONDecoder()
-        guard let rateResult = try decoder.decode(RPCResponse<RateLimitsResult>.self, from: rateLimitsResponse).result,
-              let usageResult = try decoder.decode(RPCResponse<UsageResult>.self, from: usageResponse).result else {
+        guard let rateResult = try decoder.decode(
+            RPCResponse<RateLimitsResult>.self,
+            from: rateLimitsResponse
+        ).result else {
             throw CodexClientError.invalidResponse
         }
+        let usageResult = try decoder.decode(
+            RPCResponse<UsageResult>.self,
+            from: usageResponse
+        ).result
 
         let snapshots = rateResult.rateLimitsByLimitId ?? ["codex": rateResult.rateLimits]
         let mainSnapshot = snapshots["codex"] ?? rateResult.rateLimits
@@ -788,7 +791,7 @@ actor CodexClient {
         dateFormatter.timeZone = TimeZone(secondsFromGMT: 0)
         dateFormatter.dateFormat = "yyyy-MM-dd"
         dateFormatter.isLenient = false
-        let tokenHistory = try (usageResult.dailyUsageBuckets ?? []).map { bucket in
+        let tokenHistory = try (usageResult?.dailyUsageBuckets ?? []).map { bucket in
             guard bucket.tokens >= 0,
                   let date = dateFormatter.date(from: bucket.startDate) else {
                 throw CodexClientError.invalidResponse
@@ -800,7 +803,7 @@ actor CodexClient {
                 completeness: endOfDay <= fetchedAt ? .complete : .partial
             )
         }
-        let summary = usageResult.summary
+        let summary = usageResult?.summary
         let summaryCounts = [
             summary?.lifetimeTokens,
             summary?.peakDailyTokens,
@@ -1011,8 +1014,41 @@ actor CodexClient {
 
 }
 
-private struct RPCResponse<Result: Decodable>: Decodable {
+private struct RPCError: Decodable {
+    let code: Int
+    let message: String
+}
+
+private struct InitializeResult: Decodable {
+    let userAgent: String?
+}
+
+struct RPCResponse<Result: Decodable>: Decodable {
     let result: Result?
+    private let error: RPCError?
+
+    private enum CodingKeys: String, CodingKey {
+        case result
+        case error
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let containsOneMember =
+            container.contains(.result) != container.contains(.error)
+        result = try container.decodeIfPresent(Result.self, forKey: .result)
+        error = try container.decodeIfPresent(RPCError.self, forKey: .error)
+        guard containsOneMember,
+              (result != nil) != (error != nil) else {
+            throw DecodingError.dataCorrupted(
+                .init(
+                    codingPath: decoder.codingPath,
+                    debugDescription:
+                        "JSON-RPC response needs either result or error"
+                )
+            )
+        }
+    }
 }
 
 private struct RateLimitsResult: Decodable {

--- a/Sources/CodexLimits/CodexClient.swift
+++ b/Sources/CodexLimits/CodexClient.swift
@@ -26,7 +26,7 @@ enum CodexClient {
         do {
             let version = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "0.1.0"
             try write(
-                #"{"id":1,"method":"initialize","params":{"clientInfo":{"name":"codex-limits","title":"Codex Limits","version":"\#(version)"},"capabilities":{"experimentalApi":true}}}"#,
+                #"{"id":\#(RequestID.initialize.rawValue),"method":"initialize","params":{"clientInfo":{"name":"codex-limits","title":"Codex Limits","version":"\#(version)"},"capabilities":{"experimentalApi":true}}}"#,
                 to: input.fileHandleForWriting
             )
             let fetchedAt = Date()
@@ -170,32 +170,31 @@ enum CodexClient {
                   let rawID = object["id"] as? Int,
                   let id = RequestID(rawValue: rawID) else { continue }
 
-            if object["error"] != nil {
+            if object.keys.contains("error") {
+                guard (try? JSONDecoder().decode(RPCErrorEnvelope.self, from: data)) != nil else {
+                    throw CodexClientError.invalidResponse
+                }
                 switch id {
-                case .rateLimits:
+                case .initialize, .rateLimits:
                     throw CodexClientError.invalidResponse
                 case .usage:
                     usageRequestFinished = true
-                default:
-                    continue
                 }
-            }
-
-            switch id {
-            case .initialize:
-                try write(#"{"method":"initialized"}"#, to: input)
-                try write(
-                    #"{"id":\#(RequestID.rateLimits.rawValue),"method":"account/rateLimits/read"}"#,
-                    to: input
-                )
-                try write(
-                    #"{"id":\#(RequestID.usage.rawValue),"method":"account/usage/read"}"#,
-                    to: input
-                )
-            case .rateLimits:
-                rateLimitsResponse = data
-            case .usage:
-                if object["error"] == nil {
+            } else {
+                switch id {
+                case .initialize:
+                    try write(#"{"method":"initialized"}"#, to: input)
+                    try write(
+                        #"{"id":\#(RequestID.rateLimits.rawValue),"method":"account/rateLimits/read"}"#,
+                        to: input
+                    )
+                    try write(
+                        #"{"id":\#(RequestID.usage.rawValue),"method":"account/usage/read"}"#,
+                        to: input
+                    )
+                case .rateLimits:
+                    rateLimitsResponse = data
+                case .usage:
                     usageResponse = data
                     usageRequestFinished = true
                 }
@@ -217,6 +216,15 @@ private enum RequestID: Int {
     case initialize = 1
     case rateLimits = 2
     case usage = 3
+}
+
+private struct RPCErrorEnvelope: Decodable {
+    let error: RPCError
+}
+
+private struct RPCError: Decodable {
+    let code: Double
+    let message: String
 }
 
 private struct RPCResponse<Result: Decodable>: Decodable {

--- a/Sources/CodexLimits/CodexClientError.swift
+++ b/Sources/CodexLimits/CodexClientError.swift
@@ -1,0 +1,28 @@
+//
+//  CodexClientError.swift
+//  CodexLimits
+//
+//  Created by Erfan on 27/7/26.
+//
+
+import Foundation
+
+enum CodexClientError: LocalizedError {
+    case cliNotFound
+    case invalidResponse
+    case mainLimitMissing
+    case timedOut
+
+    var errorDescription: String? {
+        switch self {
+        case .cliNotFound:
+            "Codex CLI was not found. Install it with Homebrew, sign in, and try again."
+        case .invalidResponse:
+            "Codex returned data this app could not read. Update Codex CLI and try again."
+        case .mainLimitMissing:
+            "Codex did not return a usable limit. Make sure Codex CLI is signed in."
+        case .timedOut:
+            "Codex took too long to respond. Try refreshing again."
+        }
+    }
+}

--- a/Sources/CodexLimits/ThreadProjectionSource.swift
+++ b/Sources/CodexLimits/ThreadProjectionSource.swift
@@ -61,12 +61,15 @@ struct ReadOnlyThreadProjectionSource: Sendable {
             )
         )
         let response = try JSONDecoder().decode(
-            ThreadListRPCResponse.self,
+            RPCResponse<ThreadListResult>.self,
             from: data
         )
+        guard let result = response.result else {
+            throw CodexClientError.invalidResponse
+        }
         return ThreadProjectionPage(
-            tasks: response.result.data.map(projection),
-            nextCursor: response.result.nextCursor
+            tasks: result.data.map(projection),
+            nextCursor: result.nextCursor
         )
     }
 
@@ -75,10 +78,13 @@ struct ReadOnlyThreadProjectionSource: Sendable {
             .read(threadID: threadID, includeTurns: false)
         )
         let response = try JSONDecoder().decode(
-            ThreadReadRPCResponse.self,
+            RPCResponse<ThreadReadResult>.self,
             from: data
         )
-        return projection(response.result.thread)
+        guard let result = response.result else {
+            throw CodexClientError.invalidResponse
+        }
+        return projection(result.thread)
     }
 
     private func projection(_ thread: ThreadProjectionWire) -> ThreadProjection {
@@ -113,21 +119,13 @@ struct ReadOnlyThreadProjectionSource: Sendable {
     }
 }
 
-private struct ThreadListRPCResponse: Decodable {
-    let result: Result
-
-    struct Result: Decodable {
-        let data: [ThreadProjectionWire]
-        let nextCursor: String?
-    }
+private struct ThreadListResult: Decodable {
+    let data: [ThreadProjectionWire]
+    let nextCursor: String?
 }
 
-private struct ThreadReadRPCResponse: Decodable {
-    let result: Result
-
-    struct Result: Decodable {
-        let thread: ThreadProjectionWire
-    }
+private struct ThreadReadResult: Decodable {
+    let thread: ThreadProjectionWire
 }
 
 private struct ThreadProjectionWire: Decodable {

--- a/Tests/CodexLimitsTests/CodexClientTests.swift
+++ b/Tests/CodexLimitsTests/CodexClientTests.swift
@@ -136,6 +136,31 @@ final class CodexClientTests: XCTestCase {
         XCTAssertEqual(server.threadReadCount, 1)
     }
 
+    func testThreadProjectionRejectsResultAndErrorEnvelope() async {
+        let server = PersistentAppServerFixture(
+            errorBodiesByMethod: [
+                "thread/list":
+                    #"{"code":-32603,"message":"Error"},"result":{"data":[],"nextCursor":null}"#
+            ]
+        )
+        let client = CodexClient(
+            makeConnection: server.makeConnection,
+            timeout: 1
+        )
+        let source = ReadOnlyThreadProjectionSource { request in
+            try await client.threadProjectionResponse(for: request)
+        }
+
+        do {
+            _ = try await source.list(cursor: nil, limit: 25)
+            XCTFail("Expected result and error to be rejected")
+        } catch is DecodingError {
+            // Expected.
+        } catch {
+            XCTFail("Expected DecodingError, got \(error)")
+        }
+    }
+
     func testReadsInstalledCLIVersionFromTheInitializedSession() async throws {
         let server = PersistentAppServerFixture(
             initializeUserAgent: "Codex Desktop/0.145.0 (Mac OS 15.5)"
@@ -446,6 +471,66 @@ final class CodexClientTests: XCTestCase {
             XCTFail("Expected invalidResponse, got \(error)")
         }
         XCTAssertEqual(server.connectionCount, 1)
+    }
+
+    func testUsageRPCErrorKeepsRateLimitsAvailable() async throws {
+        let server = PersistentAppServerFixture(
+            errorBodiesByMethod: [
+                "account/usage/read":
+                    #"{"code":-32603,"message":"Usage is temporarily unavailable"}"#
+            ]
+        )
+        let client = CodexClient(
+            makeConnection: server.makeConnection,
+            timeout: 1
+        )
+
+        let result = try await client.fetch(
+            fetchedAt: Date(timeIntervalSince1970: 1_900_000)
+        )
+
+        XCTAssertEqual(result.snapshot.mainLimit?.window.remainingPercent, 80)
+        XCTAssertEqual(result.snapshot.tokenHistory, [])
+        XCTAssertEqual(
+            result.account,
+            .stable(identity: "user@example.com")
+        )
+    }
+
+    func testRequiredRPCErrorRemainsFatal() async {
+        let error =
+            #"{"code":-32603,"message":"Temporarily unavailable"}"#
+
+        for method in ["initialize", "account/rateLimits/read"] {
+            await assertInvalidFetch(
+                errorBodiesByMethod: [method: error]
+            )
+        }
+    }
+
+    func testNullInitializationResultRemainsFatal() async {
+        await assertInvalidFetch(
+            initializationResultBody: "null"
+        )
+    }
+
+    func testMalformedUsageRPCErrorRemainsFatal() async {
+        let malformedErrors = [
+            "null",
+            #""bad envelope""#,
+            #"{"message":"Missing code"}"#,
+            #"{"code":-32603}"#,
+            #"{"code":-32603.5,"message":"Code must be an integer"}"#,
+            #"{"code":-32603,"message":"Error"},"result":{}"#,
+            #"null,"result":{}"#,
+            #"{"code":-32603,"message":"Error"},"result":null"#
+        ]
+
+        for error in malformedErrors {
+            await assertInvalidFetch(
+                errorBodiesByMethod: ["account/usage/read": error]
+            )
+        }
     }
 
     func testMissingWeeklyWindowKeepsOtherLimitsWithoutRestarting() async throws {
@@ -913,6 +998,36 @@ final class CodexClientTests: XCTestCase {
         XCTAssertNil(result.account)
     }
 
+    private func assertInvalidFetch(
+        errorBodiesByMethod: [String: String] = [:],
+        initializationResultBody: String? = nil,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) async {
+        let server = PersistentAppServerFixture(
+            errorBodiesByMethod: errorBodiesByMethod,
+            initializationResultBody: initializationResultBody
+        )
+        let client = CodexClient(
+            makeConnection: server.makeConnection,
+            timeout: 1
+        )
+        do {
+            _ = try await client.fetch(
+                fetchedAt: Date(timeIntervalSince1970: 1_900_000)
+            )
+            XCTFail("Expected invalidResponse", file: file, line: line)
+        } catch CodexClientError.invalidResponse {
+            // Expected.
+        } catch {
+            XCTFail(
+                "Expected invalidResponse, got \(error)",
+                file: file,
+                line: line
+            )
+        }
+    }
+
 }
 
 private final class ExecutableIdentityFixture: @unchecked Sendable {
@@ -946,6 +1061,8 @@ private final class PersistentAppServerFixture: @unchecked Sendable {
     private let delaysFirstRateLimitResponse: Bool
     private let initializeUserAgent: String?
     private let includesChangingResetDetails: Bool
+    private let errorBodiesByMethod: [String: String]
+    private let initializationResultBody: String?
     private var connections = 0
     private var initializations = 0
     private var rateLimitReads = 0
@@ -994,7 +1111,9 @@ private final class PersistentAppServerFixture: @unchecked Sendable {
         omitsWeeklyWindow: Bool = false,
         delaysFirstRateLimitResponse: Bool = false,
         initializeUserAgent: String? = nil,
-        includesChangingResetDetails: Bool = false
+        includesChangingResetDetails: Bool = false,
+        errorBodiesByMethod: [String: String] = [:],
+        initializationResultBody: String? = nil
     ) {
         self.dropsFirstConnection = dropsFirstConnection
         self.stallsFirstConnection = stallsFirstConnection
@@ -1008,6 +1127,8 @@ private final class PersistentAppServerFixture: @unchecked Sendable {
         self.delaysFirstRateLimitResponse = delaysFirstRateLimitResponse
         self.initializeUserAgent = initializeUserAgent
         self.includesChangingResetDetails = includesChangingResetDetails
+        self.errorBodiesByMethod = errorBodiesByMethod
+        self.initializationResultBody = initializationResultBody
     }
 
     func makeConnection() throws -> CodexAppServerConnection {
@@ -1027,10 +1148,20 @@ private final class PersistentAppServerFixture: @unchecked Sendable {
                     continue
                 }
                 var response: String
+                if let error = errorBodiesByMethod[method] {
+                    response = #"{"id":\#(id),"error":\#(error)}"#
+                    try responses.fileHandleForWriting.write(
+                        contentsOf: Data((response + "\n").utf8)
+                    )
+                    continue
+                }
                 switch method {
                 case "initialize":
                     lock.withLock { initializations += 1 }
-                    if let initializeUserAgent {
+                    if let initializationResultBody {
+                        response =
+                            #"{"id":\#(id),"result":\#(initializationResultBody)}"#
+                    } else if let initializeUserAgent {
                         response = #"{"id":\#(id),"result":{"userAgent":"\#(initializeUserAgent)"}}"#
                     } else {
                         response = #"{"id":\#(id),"result":{}}"#

--- a/Tests/CodexLimitsTests/CodexClientTests.swift
+++ b/Tests/CodexLimitsTests/CodexClientTests.swift
@@ -39,19 +39,10 @@ final class CodexClientTests: XCTestCase {
     }
 
     func testUsageRPCErrorDoesNotDiscardRateLimits() async throws {
-        let serverOutput = Pipe()
-        let clientInput = Pipe()
-        let rateLimits = Self.rateLimitsResponse
-        let usageError = #"{"id":3,"error":{"code":-32603,"message":"Usage is temporarily unavailable"}}"#
-        try serverOutput.fileHandleForWriting.write(
-            contentsOf: Data((usageError + "\n" + rateLimits + "\n").utf8)
-        )
-        try serverOutput.fileHandleForWriting.close()
-        let fetchedAt = Date(timeIntervalSince1970: 1_900_000)
+        let fetchedAt = Self.fetchedAt
 
-        let result = try await CodexClient.readSnapshot(
-            from: serverOutput.fileHandleForReading,
-            writingTo: clientInput.fileHandleForWriting,
+        let result = try await readSnapshot(
+            responses: [Self.usageErrorResponse, Self.rateLimitsResponse],
             fetchedAt: fetchedAt
         )
 
@@ -60,26 +51,41 @@ final class CodexClientTests: XCTestCase {
         XCTAssertEqual(result.fetchedAt, fetchedAt)
     }
 
-    func testRateLimitsRPCErrorRemainsFailure() async throws {
-        let serverOutput = Pipe()
-        let clientInput = Pipe()
-        let rateLimitsError = #"{"id":2,"error":{"code":-32603,"message":"Rate limits are temporarily unavailable"}}"#
-        try serverOutput.fileHandleForWriting.write(
-            contentsOf: Data((rateLimitsError + "\n").utf8)
+    func testUsageRPCErrorAfterRateLimitsDoesNotDiscardRateLimits() async throws {
+        let result = try await readSnapshot(
+            responses: [Self.rateLimitsResponse, Self.usageErrorResponse],
+            fetchedAt: Self.fetchedAt
         )
-        try serverOutput.fileHandleForWriting.close()
 
-        do {
-            _ = try await CodexClient.readSnapshot(
-                from: serverOutput.fileHandleForReading,
-                writingTo: clientInput.fileHandleForWriting,
-                fetchedAt: Date(timeIntervalSince1970: 1_900_000)
+        XCTAssertEqual(result.mainLimit.window.remainingPercent, 80)
+        XCTAssertEqual(result.tokenHistory, [])
+        XCTAssertEqual(result.fetchedAt, Self.fetchedAt)
+    }
+
+    func testRateLimitsRPCErrorRemainsFailure() async throws {
+        let rateLimitsError = #"{"id":2,"error":{"code":-32603,"message":"Rate limits are temporarily unavailable"}}"#
+
+        try await assertInvalidResponse(responses: [rateLimitsError])
+    }
+
+    func testInitializationRPCErrorRemainsFailure() async throws {
+        let initializationError = #"{"id":1,"error":{"code":-32603,"message":"Initialization failed"}}"#
+
+        try await assertInvalidResponse(responses: [initializationError])
+    }
+
+    func testMalformedUsageRPCErrorRemainsFailure() async throws {
+        let malformedErrors = [
+            #"{"id":3,"error":null}"#,
+            #"{"id":3,"error":"bad envelope"}"#,
+            #"{"id":3,"error":{"message":"Missing code"}}"#,
+            #"{"id":3,"error":{"code":-32603}}"#
+        ]
+
+        for malformedError in malformedErrors {
+            try await assertInvalidResponse(
+                responses: [Self.rateLimitsResponse, malformedError]
             )
-            XCTFail("Expected the rate-limits error to remain fatal")
-        } catch let error as CodexClientError {
-            guard case .invalidResponse = error else {
-                return XCTFail("Expected invalidResponse, got \(error)")
-            }
         }
     }
 
@@ -96,10 +102,52 @@ final class CodexClientTests: XCTestCase {
             try CodexClient.decode(
                 rateLimitsResponse: Data(Self.rateLimitsResponse.utf8),
                 usageResponse: usage,
-                fetchedAt: Date(timeIntervalSince1970: 1_900_000)
+                fetchedAt: Self.fetchedAt
             )
         )
     }
 
+    private func readSnapshot(
+        responses: [String],
+        fetchedAt: Date
+    ) async throws -> UsageSnapshot {
+        let serverOutput = Pipe()
+        let clientInput = Pipe()
+        try serverOutput.fileHandleForWriting.write(
+            contentsOf: Data((responses.joined(separator: "\n") + "\n").utf8)
+        )
+        try serverOutput.fileHandleForWriting.close()
+
+        return try await CodexClient.readSnapshot(
+            from: serverOutput.fileHandleForReading,
+            writingTo: clientInput.fileHandleForWriting,
+            fetchedAt: fetchedAt
+        )
+    }
+
+    private func assertInvalidResponse(
+        responses: [String],
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) async throws {
+        do {
+            _ = try await readSnapshot(
+                responses: responses,
+                fetchedAt: Self.fetchedAt
+            )
+            XCTFail("Expected invalidResponse", file: file, line: line)
+        } catch let error as CodexClientError {
+            guard case .invalidResponse = error else {
+                return XCTFail(
+                    "Expected invalidResponse, got \(error)",
+                    file: file,
+                    line: line
+                )
+            }
+        }
+    }
+
+    private static let fetchedAt = Date(timeIntervalSince1970: 1_900_000)
+    private static let usageErrorResponse = #"{"id":3,"error":{"code":-32603,"message":"Usage is temporarily unavailable"}}"#
     private static let rateLimitsResponse = #"{"id":2,"result":{"rateLimits":{"limitId":"codex","primary":{"usedPercent":20,"windowDurationMins":10080,"resetsAt":2000000}},"rateLimitsByLimitId":{"codex":{"limitId":"codex","primary":{"usedPercent":20,"windowDurationMins":10080,"resetsAt":2000000}}},"rateLimitResetCredits":{"availableCount":3}}}"#
 }

--- a/Tests/CodexLimitsTests/CodexClientTests.swift
+++ b/Tests/CodexLimitsTests/CodexClientTests.swift
@@ -37,4 +37,69 @@ final class CodexClientTests: XCTestCase {
         XCTAssertEqual(result.emergencyResetCount, 3)
         XCTAssertEqual(result.fetchedAt, fetchedAt)
     }
+
+    func testUsageRPCErrorDoesNotDiscardRateLimits() async throws {
+        let serverOutput = Pipe()
+        let clientInput = Pipe()
+        let rateLimits = Self.rateLimitsResponse
+        let usageError = #"{"id":3,"error":{"code":-32603,"message":"Usage is temporarily unavailable"}}"#
+        try serverOutput.fileHandleForWriting.write(
+            contentsOf: Data((usageError + "\n" + rateLimits + "\n").utf8)
+        )
+        try serverOutput.fileHandleForWriting.close()
+        let fetchedAt = Date(timeIntervalSince1970: 1_900_000)
+
+        let result = try await CodexClient.readSnapshot(
+            from: serverOutput.fileHandleForReading,
+            writingTo: clientInput.fileHandleForWriting,
+            fetchedAt: fetchedAt
+        )
+
+        XCTAssertEqual(result.mainLimit.window.remainingPercent, 80)
+        XCTAssertEqual(result.tokenHistory, [])
+        XCTAssertEqual(result.fetchedAt, fetchedAt)
+    }
+
+    func testRateLimitsRPCErrorRemainsFailure() async throws {
+        let serverOutput = Pipe()
+        let clientInput = Pipe()
+        let rateLimitsError = #"{"id":2,"error":{"code":-32603,"message":"Rate limits are temporarily unavailable"}}"#
+        try serverOutput.fileHandleForWriting.write(
+            contentsOf: Data((rateLimitsError + "\n").utf8)
+        )
+        try serverOutput.fileHandleForWriting.close()
+
+        do {
+            _ = try await CodexClient.readSnapshot(
+                from: serverOutput.fileHandleForReading,
+                writingTo: clientInput.fileHandleForWriting,
+                fetchedAt: Date(timeIntervalSince1970: 1_900_000)
+            )
+            XCTFail("Expected the rate-limits error to remain fatal")
+        } catch let error as CodexClientError {
+            guard case .invalidResponse = error else {
+                return XCTFail("Expected invalidResponse, got \(error)")
+            }
+        }
+    }
+
+    func testMalformedUsageResponseRemainsFailure() throws {
+        let usage = Data(#"""
+        {"id":3,"result":{
+          "dailyUsageBuckets":[
+            {"startDate":"2001-01-01","tokens":"not-a-number"}
+          ]
+        }}
+        """#.utf8)
+
+        XCTAssertThrowsError(
+            try CodexClient.decode(
+                rateLimitsResponse: Data(Self.rateLimitsResponse.utf8),
+                usageResponse: usage,
+                fetchedAt: Date(timeIntervalSince1970: 1_900_000)
+            )
+        )
+    }
+
+    private static let rateLimitsResponse = #"{"id":2,"result":{"rateLimits":{"limitId":"codex","primary":{"usedPercent":20,"windowDurationMins":10080,"resetsAt":2000000}},"rateLimitsByLimitId":{"codex":{"limitId":"codex","primary":{"usedPercent":20,"windowDurationMins":10080,"resetsAt":2000000}}},"rateLimitResetCredits":{"availableCount":3}}}"#
 }


### PR DESCRIPTION
# Keep limits available when usage history fails

<img width="952" height="458" alt="Codex usage history error" src="https://github.com/user-attachments/assets/7df56628-a638-4d9e-ac5a-442207653226" />

## Issue

Codex Limits can receive a valid rate-limit response while the separate usage-history request fails. The app should still show the current remaining allowance and reset time.

## Fix

- A valid account/usage/read error now removes only that refresh's token history.
- Initialization and rate-limit errors remain fatal.
- Malformed JSON-RPC errors, null members, and envelopes with both result and error fail closed.
- Account and thread reads use the same response contract.
- The current persistent client, dynamic request IDs, reconciliation, reconnect, and account behavior stay intact.

## Maintainer integration

The original commits and Erfan's authorship remain in this branch. The final implementation adapts their behavior to the current client instead of restoring the older request flow.

## Checks

- 421 Swift tests pass locally.
- Full-screen QA passed for refresh, account facts, task reads, and Usage Receipts.
- Ponytail, spec, code, and security reviews report no remaining findings.