### PR TITLE
Restore usage history after v0.2 upgrade

### DIFF
--- a/Sources/CodexLimits/AnalyticsWorkspace.swift
+++ b/Sources/CodexLimits/AnalyticsWorkspace.swift
@@ -376,7 +376,7 @@ struct UsageChartSelection: Equatable, Sendable {
     private static func candidates(
         in chart: UsageChartSnapshot
     ) -> [Candidate] {
-        chart.observed.map {
+        chart.allObserved.map {
             Candidate(
                 series: .observed,
                 point: $0,
@@ -463,8 +463,21 @@ struct UsageChartSelection: Equatable, Sendable {
 }
 
 extension UsageChartSnapshot {
+    func availableRange(
+        including currentWindow: DateInterval
+    ) -> DateInterval {
+        guard let first = allObserved.first?.date,
+              let last = allObserved.last?.date else {
+            return currentWindow
+        }
+        return DateInterval(
+            start: min(first, currentWindow.start),
+            end: max(last, currentWindow.end)
+        )
+    }
+
     var preferredZoomAnchor: Date? {
-        observed.last?.date
+        allObserved.last?.date
     }
 }
 

--- a/Sources/CodexLimits/MenuContentView.swift
+++ b/Sources/CodexLimits/MenuContentView.swift
@@ -2087,12 +2087,19 @@ private struct UsageRemainingChart: View {
     @State private var rangeStart: Date?
     @State private var keyboardRangeStart: Date?
 
-    private var bounds: DateInterval {
+    private var currentWindowBounds: DateInterval {
         DateInterval(start: window.startsAt, end: window.resetsAt)
     }
 
+    private var bounds: DateInterval {
+        chart.availableRange(including: currentWindowBounds)
+    }
+
     private var visibleRange: DateInterval {
-        store.effectiveRange(
+        if store.state.timeRange == .currentWindow {
+            return currentWindowBounds
+        }
+        return store.effectiveRange(
             within: bounds,
             endingAt: chart.preferredZoomAnchor ?? min(Date(), bounds.end)
         )
@@ -2103,9 +2110,16 @@ private struct UsageRemainingChart: View {
     }
 
     private var xAxisDates: [Date] {
-        let step: TimeInterval = visibleRange.duration <= 2 * 86_400
-            ? 6 * 3_600
-            : 86_400
+        let step: TimeInterval
+        if visibleRange.duration <= 2 * 86_400 {
+            step = 6 * 3_600
+        } else if visibleRange.duration <= 10 * 86_400 {
+            step = 86_400
+        } else if visibleRange.duration <= 35 * 86_400 {
+            step = 7 * 86_400
+        } else {
+            step = 14 * 86_400
+        }
         return Array(
             stride(
                 from: visibleRange.start,
@@ -2138,12 +2152,21 @@ private struct UsageRemainingChart: View {
                         .foregroundStyle(Color.secondary)
                     AxisValueLabel {
                         if let date = value.as(Date.self) {
-                            Text(
-                                date,
-                                format: visibleRange.duration <= 2 * 86_400
-                                    ? .dateTime.hour()
-                                    : .dateTime.weekday(.abbreviated)
-                            )
+                            if visibleRange.duration <= 2 * 86_400 {
+                                Text(date, format: .dateTime.hour())
+                            } else if visibleRange.duration <= 10 * 86_400 {
+                                Text(
+                                    date,
+                                    format: .dateTime.weekday(.abbreviated)
+                                )
+                            } else {
+                                Text(
+                                    date,
+                                    format: .dateTime
+                                        .month(.abbreviated)
+                                        .day()
+                                )
+                            }
                         }
                     }
                     .foregroundStyle(Color.secondary)
@@ -2223,7 +2246,7 @@ private struct UsageRemainingChart: View {
     private var selectedRangeDetail: some View {
         if store.state.timeRange == .selected,
            let range = store.state.visibleRange {
-            let points = chart.observed
+            let points = chart.allObserved
                 .filter { range.contains($0.date) }
                 .sorted { $0.date < $1.date }
             if let first = points.first, let last = points.last {
@@ -2233,7 +2256,11 @@ private struct UsageRemainingChart: View {
                     )
                     .monospacedDigit()
                     Text(
-                        "\(chart.observedSource.rawValue) · \(evidence.coverage.displayName) coverage · \(evidence.confidence.displayName) confidence"
+                        evidenceLabel(
+                            inCurrentWindow:
+                                range.start >= currentWindowBounds.start
+                                && range.end <= currentWindowBounds.end
+                        )
                     )
                     .foregroundStyle(.secondary)
                 }
@@ -2289,7 +2316,7 @@ private struct UsageRemainingChart: View {
     @ChartContentBuilder
     private var observedMarks: some ChartContent {
         ForEach(
-            Array(chart.observedSegments.enumerated()),
+            Array(chart.allObservedSegments.enumerated()),
             id: \.offset
         ) { segmentIndex, segment in
             ForEach(segment) { point in
@@ -2410,14 +2437,13 @@ private struct UsageRemainingChart: View {
         .background(.quaternary.opacity(0.7), in: RoundedRectangle(cornerRadius: 8))
 
         if let selection {
-            Text(
-                "\(evidence.coverage.displayName) coverage · \(evidence.confidence.displayName) confidence"
+            let label = evidenceLabel(
+                inCurrentWindow: currentWindowBounds.contains(selection.date)
             )
+            Text(label)
             .font(.caption)
             .foregroundStyle(.secondary)
-            .accessibilityLabel(
-                "\(evidence.coverage.displayName) coverage, \(evidence.confidence.displayName) confidence"
-            )
+            .accessibilityLabel(label)
 
             HStack(spacing: 10) {
                 if let keyboardRangeStart {
@@ -2566,6 +2592,13 @@ private struct UsageRemainingChart: View {
         case .pastEstimate: .secondary
         case .estimatedBackfill: .orange
         }
+    }
+
+    private func evidenceLabel(
+        inCurrentWindow: Bool
+    ) -> String {
+        guard inCurrentWindow else { return "Account history" }
+        return "\(chart.observedSource.rawValue) · \(evidence.coverage.displayName) coverage · \(evidence.confidence.displayName) confidence"
     }
 
 }

--- a/Sources/CodexLimits/UsageIntelligenceEngine.swift
+++ b/Sources/CodexLimits/UsageIntelligenceEngine.swift
@@ -297,6 +297,14 @@ struct UsageChartSnapshot: Equatable, Sendable {
         observedSegments.flatMap { $0 }
     }
 
+    var allObservedSegments: [[UsageChartPoint]] {
+        allowanceWindows.flatMap(\.observedSegments)
+    }
+
+    var allObserved: [UsageChartPoint] {
+        allObservedSegments.flatMap { $0 }
+    }
+
     var historicalProjection: [UsageChartPoint] {
         reference?.source == .accountHistory ? reference?.points ?? [] : []
     }
@@ -566,17 +574,9 @@ enum UsageIntelligenceEngine {
                 forecast: forecast
             )
         }
-        let chartSamples = input.samples.filter { sample in
-            guard let currentReset = input.account?.mainLimit?.window.resetsAt,
-                  sample.resetsAt == currentReset,
-                  let epoch = input.accountEpochStartedAt else {
-                return true
-            }
-            return sample.observedAt >= epoch
-        }
         let chart = chart(
             account: input.account,
-            samples: chartSamples,
+            samples: input.samples,
             guidance: guidance,
             safetyBuffer: input.safetyBuffer
         )

--- a/Sources/CodexLimits/UsageMonitor.swift
+++ b/Sources/CodexLimits/UsageMonitor.swift
@@ -32,6 +32,8 @@ final class UsageMonitor: ObservableObject {
     private static let historyAuthStateKey = "historyAccountState"
     private static let historyPlanTypeKey = "historyAccountPlanType"
     private static let historyAccountEpochStartedAtKey = "historyAccountEpochStartedAt"
+    private static let historyAccountEpochMigrationVersionKey =
+        "historyAccountEpochMigrationVersion"
     private static let historySyncSelectedKey = "historySyncSelected"
     private static let historySyncAccountBindingKey = "historySyncAccountBinding"
     private static let localHistoryDeletionCutoffKey =
@@ -217,6 +219,7 @@ final class UsageMonitor: ObservableObject {
             }
             let historyState = await exchangeHistory()
             apply(historyState, configuredFolderName: configuredSyncDirectory?.lastPathComponent)
+            repairInitialAccountEpochIfNeeded()
             let exchangeErrorMessage = historyState.errorMessage
             let newSnapshot = result.snapshot
             if let window = newSnapshot.mainLimit?.window {
@@ -362,6 +365,7 @@ final class UsageMonitor: ObservableObject {
         let previousPlanType = defaults.string(
             forKey: Self.historyPlanTypeKey
         )
+        var migratedEpoch: Date?
         switch observation {
         case let .stable(identity):
             historyAccountIdentity = identity
@@ -370,6 +374,11 @@ final class UsageMonitor: ObservableObject {
                 key: Self.fingerprintKey(in: defaults)
             )
             authState = "stable:\(partition.id)"
+            if previousAuthState == nil, accountEpochStartedAt == nil {
+                migratedEpoch = legacySamplesAwaitingMigration
+                    .map(\.observedAt)
+                    .min()
+            }
         case let .unknown(state):
             historyAccountIdentity = nil
             authState = "unknown:\(state)"
@@ -386,9 +395,10 @@ final class UsageMonitor: ObservableObject {
         if previousAuthState != authState
             || planChanged
             || accountEpochStartedAt == nil {
-            accountEpochStartedAt = observedAt
+            let epoch = migratedEpoch ?? observedAt
+            accountEpochStartedAt = epoch
             defaults.set(
-                observedAt,
+                epoch,
                 forKey: Self.historyAccountEpochStartedAtKey
             )
         }
@@ -419,6 +429,46 @@ final class UsageMonitor: ObservableObject {
         if historyPrepared {
             persist()
         }
+    }
+
+    private func repairInitialAccountEpochIfNeeded() {
+        guard defaults.integer(
+            forKey: Self.historyAccountEpochMigrationVersionKey
+        ) < 1,
+        historyAccountIdentity != nil,
+        historyUsesFiles,
+        !defaults.bool(forKey: Self.historySyncSelectedKey)
+            || historyConnectionActive else {
+            return
+        }
+        defer {
+            defaults.set(
+                1,
+                forKey: Self.historyAccountEpochMigrationVersionKey
+            )
+        }
+        guard let epoch = accountEpochStartedAt,
+              let epochSample = samples.first(where: {
+                  $0.observedAt == epoch && $0.comparisonBreak
+              }),
+              !samples.contains(where: {
+                  $0.observedAt < epoch && $0.comparisonBreak
+              }) else {
+            return
+        }
+        let earlierDates = samples.compactMap {
+            $0.resetsAt == epochSample.resetsAt && $0.observedAt < epoch
+                ? $0.observedAt
+                : nil
+        }
+        guard let restoredEpoch = earlierDates.min() else {
+            return
+        }
+        accountEpochStartedAt = restoredEpoch
+        defaults.set(
+            restoredEpoch,
+            forKey: Self.historyAccountEpochStartedAtKey
+        )
     }
 
     func deleteAnalyticsHistory() async {

--- a/Tests/CodexLimitsTests/AnalyticsWorkspaceTests.swift
+++ b/Tests/CodexLimitsTests/AnalyticsWorkspaceTests.swift
@@ -327,6 +327,130 @@ final class AnalyticsWorkspaceTests: XCTestCase {
         XCTAssertEqual(selection?.date, visible)
     }
 
+    func testNearestPointIncludesPriorAllowanceWindows() {
+        let historical = Date(timeIntervalSince1970: 1_000)
+        let current = Date(timeIntervalSince1970: 5_000)
+        let chart = UsageChartSnapshot(
+            observedSource: .account,
+            target: [],
+            currentProjection: [],
+            currentAllowanceReset: current,
+            allowanceWindows: [
+                UsageAllowanceWindowSeries(
+                    resetsAt: Date(timeIntervalSince1970: 2_000),
+                    observedSegments: [[
+                        UsageChartPoint(date: historical, remaining: 40)
+                    ]]
+                ),
+                UsageAllowanceWindowSeries(
+                    resetsAt: current,
+                    observedSegments: [[
+                        UsageChartPoint(date: current, remaining: 70)
+                    ]]
+                )
+            ],
+            currentRunsFaster: false,
+            accessibilityValue: "Observed usage"
+        )
+
+        let selection = UsageChartSelection.nearest(
+            to: historical,
+            in: chart
+        )
+
+        XCTAssertEqual(selection?.date, historical)
+        XCTAssertEqual(selection?.remaining, 40)
+    }
+
+    func testUsageChartRangeIncludesPriorAllowanceWindows() {
+        let historical = Date(timeIntervalSince1970: 1_000)
+        let currentWindow = DateInterval(
+            start: Date(timeIntervalSince1970: 4_000),
+            end: Date(timeIntervalSince1970: 8_000)
+        )
+        let chart = UsageChartSnapshot(
+            observedSource: .account,
+            target: [],
+            currentProjection: [],
+            currentAllowanceReset: currentWindow.end,
+            allowanceWindows: [
+                UsageAllowanceWindowSeries(
+                    resetsAt: Date(timeIntervalSince1970: 2_000),
+                    observedSegments: [[
+                        UsageChartPoint(date: historical, remaining: 40)
+                    ]]
+                ),
+                UsageAllowanceWindowSeries(
+                    resetsAt: currentWindow.end,
+                    observedSegments: [[
+                        UsageChartPoint(
+                            date: Date(timeIntervalSince1970: 5_000),
+                            remaining: 70
+                        )
+                    ]]
+                )
+            ],
+            currentRunsFaster: false,
+            accessibilityValue: "Observed usage"
+        )
+
+        XCTAssertEqual(
+            chart.availableRange(including: currentWindow),
+            DateInterval(start: historical, end: currentWindow.end)
+        )
+    }
+
+    func testHistoricalUsagePresetsReachBeyondTheCurrentWindow() {
+        let suite = "AnalyticsWorkspaceTests.historicalUsagePresets"
+        let defaults = UserDefaults(suiteName: suite)!
+        defer { defaults.removePersistentDomain(forName: suite) }
+        let store = AnalyticsWorkspaceStore(defaults: defaults)
+        let observedAt = Date(timeIntervalSince1970: 10_000_000)
+        let oldest = observedAt.addingTimeInterval(-84 * 86_400)
+        let currentWindow = DateInterval(
+            start: observedAt.addingTimeInterval(-7 * 86_400),
+            end: observedAt.addingTimeInterval(86_400)
+        )
+        let chart = UsageChartSnapshot(
+            observedSource: .account,
+            target: [],
+            currentProjection: [],
+            currentAllowanceReset: currentWindow.end,
+            allowanceWindows: [
+                UsageAllowanceWindowSeries(
+                    resetsAt: oldest.addingTimeInterval(7 * 86_400),
+                    observedSegments: [[
+                        UsageChartPoint(date: oldest, remaining: 100)
+                    ]]
+                ),
+                UsageAllowanceWindowSeries(
+                    resetsAt: currentWindow.end,
+                    observedSegments: [[
+                        UsageChartPoint(date: observedAt, remaining: 70)
+                    ]]
+                )
+            ],
+            currentRunsFaster: false,
+            accessibilityValue: "Observed usage"
+        )
+        let bounds = chart.availableRange(including: currentWindow)
+
+        store.selectTimeRange(.fourWeeks)
+        XCTAssertEqual(
+            store.effectiveRange(within: bounds, endingAt: observedAt),
+            DateInterval(
+                start: observedAt.addingTimeInterval(-28 * 86_400),
+                end: observedAt
+            )
+        )
+
+        store.selectTimeRange(.twelveWeeks)
+        XCTAssertEqual(
+            store.effectiveRange(within: bounds, endingAt: observedAt),
+            DateInterval(start: oldest, end: observedAt)
+        )
+    }
+
     func testKeyboardPointNavigationStartsWithoutPointerSelection() {
         let first = Date(timeIntervalSince1970: 4_000)
         let second = Date(timeIntervalSince1970: 5_000)

--- a/Tests/CodexLimitsTests/UsageIntelligenceEngineTests.swift
+++ b/Tests/CodexLimitsTests/UsageIntelligenceEngineTests.swift
@@ -1277,6 +1277,40 @@ final class UsageIntelligenceEngineTests: XCTestCase {
         )
     }
 
+    func testAccountEpochDoesNotHideStoredChartPoints() {
+        let now = Date(timeIntervalSince1970: 6_400_000)
+        let account = makeSnapshot(remaining: 70, fetchedAt: now)
+        let reset = account.mainLimit!.window.resetsAt
+        let beforeEpoch = now.addingTimeInterval(-2 * 3_600)
+        let afterEpoch = now.addingTimeInterval(-30 * 60)
+        let reader = UsageIntelligenceEngine.evaluate(
+            UsageIntelligenceInput(
+                account: account,
+                samples: [
+                    UsageSample(
+                        observedAt: beforeEpoch,
+                        remainingPercent: 80,
+                        resetsAt: reset
+                    ),
+                    UsageSample(
+                        observedAt: afterEpoch,
+                        remainingPercent: 72,
+                        resetsAt: reset
+                    )
+                ],
+                safetyBuffer: 3,
+                sourceState: .available,
+                now: now,
+                previousStatus: nil,
+                accountEpochStartedAt: now.addingTimeInterval(-3_600)
+            )
+        )
+
+        XCTAssertTrue(
+            reader.chart.observed.contains { $0.date == beforeEpoch }
+        )
+    }
+
     func testSparseHistoryWithholdsGuidance() {
         let now = Date(timeIntervalSince1970: 6_000_000)
         let reader = UsageIntelligenceEngine.evaluate(

--- a/Tests/CodexLimitsTests/UsageMonitorHistoryTests.swift
+++ b/Tests/CodexLimitsTests/UsageMonitorHistoryTests.swift
@@ -252,6 +252,31 @@ final class UsageMonitorHistoryTests: XCTestCase {
             monitor.readerSnapshot.accountTokenActivity.reason,
             "No lifetime token reading at the weekly boundary"
         )
+
+        defaults.removeObject(
+            forKey: "historyAccountEpochMigrationVersion"
+        )
+        let restartSource = FetchSequence([
+            makeFetchResult(
+                identity: "first@example.com",
+                fetchedAt: Date(timeIntervalSince1970: 1_900_060),
+                remaining: 79,
+                lifetimeTokens: 1_610
+            )
+        ])
+        let restarted = UsageMonitor(
+            defaults: defaults,
+            historyDirectory: root,
+            startsAutomatically: false,
+            fetchUsage: { try await restartSource.next() }
+        )
+
+        await restarted.refresh()
+
+        XCTAssertEqual(
+            defaults.object(forKey: "historyAccountEpochStartedAt") as? Date,
+            Date(timeIntervalSince1970: 1_900_000)
+        )
     }
 
     func testPlanChangeRecordsADurableComparisonBreak() async throws {
@@ -985,6 +1010,133 @@ final class UsageMonitorHistoryTests: XCTestCase {
         await monitor.refresh()
 
         XCTAssertEqual(monitor.samples.map(\.remainingPercent), [81, 80])
+    }
+
+    func testFirstStableAccountKeepsLegacyCurrentWindowCoverage() async throws {
+        let suiteName = "UsageMonitorHistoryTests-\(UUID().uuidString)"
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        let root = temporaryDirectory()
+        let windowStart = Date(timeIntervalSince1970: 1_395_200)
+        let fetchedAt = Date(timeIntervalSince1970: 1_900_000)
+        let observations = Array(
+            stride(
+                from: windowStart.timeIntervalSince1970,
+                to: fetchedAt.timeIntervalSince1970,
+                by: 30 * 60
+            )
+        )
+        let legacy = observations.enumerated().map { index, timestamp in
+            UsageSample(
+                observedAt: Date(timeIntervalSince1970: timestamp),
+                remainingPercent:
+                    100 - 20 * Double(index) / Double(observations.count),
+                resetsAt: Date(timeIntervalSince1970: 2_000_000)
+            )
+        }
+        defaults.set(
+            try JSONEncoder().encode(StoredStateFixture(
+                snapshot: nil,
+                samples: legacy,
+                previousStatus: nil
+            )),
+            forKey: "usageState"
+        )
+        let source = FetchSequence([
+            makeFetchResult(
+                identity: "user@example.com",
+                fetchedAt: fetchedAt,
+                remaining: 80
+            )
+        ])
+        let monitor = UsageMonitor(
+            defaults: defaults,
+            historyDirectory: root,
+            startsAutomatically: false,
+            fetchUsage: { try await source.next() }
+        )
+
+        await monitor.refresh()
+
+        XCTAssertEqual(monitor.readerSnapshot.evidence.coverage, .complete)
+        XCTAssertEqual(monitor.readerSnapshot.evidence.confidence, .high)
+    }
+
+    func testExistingV02EpochRestoresEarlierFileBackedCoverage() async throws {
+        let suiteName = "UsageMonitorHistoryTests-\(UUID().uuidString)"
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        let root = temporaryDirectory()
+        let windowStart = Date(timeIntervalSince1970: 1_395_200)
+        let firstReadAt = Date(timeIntervalSince1970: 1_900_000)
+        let firstSource = FetchSequence([
+            makeFetchResult(
+                identity: "user@example.com",
+                fetchedAt: firstReadAt,
+                remaining: 80
+            )
+        ])
+        let first = UsageMonitor(
+            defaults: defaults,
+            historyDirectory: root,
+            startsAutomatically: false,
+            fetchUsage: { try await firstSource.next() }
+        )
+        await first.refresh()
+        defaults.removeObject(
+            forKey: "historyAccountEpochMigrationVersion"
+        )
+        let partitionData = try XCTUnwrap(
+            defaults.data(forKey: "historyAccountPartition")
+        )
+        let partition = try JSONDecoder().decode(
+            AccountHistoryPartition.self,
+            from: partitionData
+        )
+        let observations = Array(
+            stride(
+                from: windowStart.timeIntervalSince1970,
+                to: firstReadAt.timeIntervalSince1970,
+                by: 30 * 60
+            )
+        )
+        let legacy = observations.enumerated().map { index, timestamp in
+            UsageSample(
+                observedAt: Date(timeIntervalSince1970: timestamp),
+                remainingPercent:
+                    100 - 20 * Double(index) / Double(observations.count),
+                resetsAt: Date(timeIntervalSince1970: 2_000_000)
+            )
+        }
+        let history = UsageHistory(
+            localDirectory: root,
+            installationID: "v02-fixture",
+            partition: partition
+        )
+        _ = await history.load(legacySamples: legacy)
+        let secondReadAt = firstReadAt.addingTimeInterval(60)
+        let secondSource = FetchSequence([
+            makeFetchResult(
+                identity: "user@example.com",
+                fetchedAt: secondReadAt,
+                remaining: 79
+            )
+        ])
+        let restarted = UsageMonitor(
+            defaults: defaults,
+            historyDirectory: root,
+            startsAutomatically: false,
+            fetchUsage: { try await secondSource.next() }
+        )
+
+        await restarted.refresh()
+
+        XCTAssertEqual(restarted.readerSnapshot.evidence.coverage, .complete)
+        XCTAssertEqual(restarted.readerSnapshot.evidence.confidence, .high)
+        XCTAssertEqual(
+            defaults.object(forKey: "historyAccountEpochStartedAt") as? Date,
+            windowStart
+        )
     }
 
     func testUnresolvableSavedSyncTargetKeepsDeletionPending() async throws {


### PR DESCRIPTION
Closes #29

## What changed
- repair the first v0.2 account epoch when earlier samples from the same weekly window exist
- retain observations from earlier allowance windows for 4-week and 12-week views
- keep current-window coverage and confidence scoped to the current account epoch
- show historical point and range provenance in visible and accessibility text

## Safety
- the migration runs once and only lowers the initial v0.2 epoch when no earlier account or plan break exists
- sync-backed repair waits until the selected sync folder is connected
- no history file is rewritten or deleted

## Checks
- 416 Swift tests pass
- full-screen QA passed for Current window, 4 weeks, 12 weeks, selection, zoom, reset, and accessibility labels
- Ponytail, code, spec, and standards reviews report no remaining findings