### PR TITLE
Restore current and past usage estimates

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Codex Limits keeps three kinds of values separate:
 - **Local facts** come from Codex records on this Mac.
 - **Derived estimates** name their Coverage and Confidence.
 
-The app hides weak estimates and says what data is missing. It shows account and local token totals side by side when they differ.
+The app keeps weak estimates out of guidance and Insights. The Usage remaining chart may still show a Current or Past estimate when it has enough fresh points to show a useful direction. The chart names its source, Coverage, and Confidence.
 
 ## Features
 
@@ -87,7 +87,7 @@ The app hides weak estimates and says what data is missing. It shows account and
 4. It uses those sources to make charts, facts, and Insights.
 5. It sends a request to Codex only when you choose an `Analyze with Codex` action.
 
-Coverage says how much needed data the app saw. Confidence says how well that data supports an estimate. The app hides Low-confidence estimates.
+Coverage says how much needed data the app saw. Confidence says how well that data supports an estimate. Low-confidence chart lines do not change guidance or Insights.
 
 ## Privacy
 

--- a/Resources/Info.plist
+++ b/Resources/Info.plist
@@ -13,9 +13,9 @@
     <key>CFBundlePackageType</key>
     <string>APPL</string>
     <key>CFBundleShortVersionString</key>
-    <string>0.2.1</string>
+    <string>0.2.2</string>
     <key>CFBundleVersion</key>
-    <string>3</string>
+    <string>4</string>
     <key>LSApplicationCategoryType</key>
     <string>public.app-category.developer-tools</string>
     <key>LSMinimumSystemVersion</key>

--- a/Sources/CodexLimits/ForecastEngine.swift
+++ b/Sources/CodexLimits/ForecastEngine.swift
@@ -135,7 +135,7 @@ enum ForecastEngine {
         .map(\.1)
     }
 
-    private static func median(_ values: [Double]) -> Double {
+    static func median(_ values: [Double]) -> Double {
         let ordered = values.sorted()
         guard !ordered.isEmpty else { return 0 }
         let middle = ordered.count / 2

--- a/Sources/CodexLimits/MenuContentView.swift
+++ b/Sources/CodexLimits/MenuContentView.swift
@@ -2286,7 +2286,7 @@ private struct UsageRemainingChart: View {
         }
         if !chart.historicalProjection.isEmpty {
             ChartLegendItem(
-                label: "Past estimate",
+                label: "Past estimate · Account history",
                 color: .secondary,
                 dash: [2, 3]
             )

--- a/Sources/CodexLimits/UsageIntelligenceEngine.swift
+++ b/Sources/CodexLimits/UsageIntelligenceEngine.swift
@@ -534,12 +534,14 @@ enum UsageIntelligenceEngine {
             now: input.now,
             workloadMixChanged: workloadMixChanged
         )
-        let guidance: UsageGuidance? = input.account.flatMap { account in
+        let forecast: Forecast? = input.account.flatMap { account in
             guard let weeklyLimit = account.mainLimit else { return nil }
-            guard evidence.confidence == .high || evidence.confidence == .medium else {
+            guard case .available = input.sourceState,
+                  input.now >= weeklyLimit.window.startsAt,
+                  input.now < weeklyLimit.window.resetsAt else {
                 return nil
             }
-            let forecast = ForecastEngine.evaluate(
+            return ForecastEngine.evaluate(
                 window: weeklyLimit.window,
                 samples: input.samples,
                 tokenHistory: account.tokenHistory,
@@ -547,6 +549,12 @@ enum UsageIntelligenceEngine {
                 now: input.now,
                 previousStatus: input.previousStatus
             )
+        }
+        let guidance: UsageGuidance? = forecast.flatMap { forecast in
+            guard evidence.confidence == .high || evidence.confidence == .medium else {
+                return nil
+            }
+            guard let weeklyLimit = input.account?.mainLimit else { return nil }
             return UsageGuidance(
                 source: .derivedEstimate,
                 status: forecast.status,
@@ -577,7 +585,7 @@ enum UsageIntelligenceEngine {
         let chart = chart(
             account: input.account,
             samples: input.samples,
-            guidance: guidance,
+            forecast: forecast,
             safetyBuffer: input.safetyBuffer
         )
         let currentFreshness = freshness(
@@ -955,7 +963,7 @@ enum UsageIntelligenceEngine {
     private static func chart(
         account: UsageSnapshot?,
         samples: [UsageSample],
-        guidance: UsageGuidance?,
+        forecast: Forecast?,
         safetyBuffer: Double
     ) -> UsageChartSnapshot {
         guard let account, let weeklyLimit = account.mainLimit else {
@@ -978,7 +986,7 @@ enum UsageIntelligenceEngine {
             account: account,
             samples: samples
         )
-        guard let forecast = guidance?.forecast else {
+        guard let forecast else {
             return UsageChartSnapshot(
                 observedSource: .account,
                 target: target,
@@ -989,20 +997,35 @@ enum UsageIntelligenceEngine {
                 accessibilityValue: "Now has \(Int(window.remainingPercent.rounded())) percent remaining. A forecast is not available."
             )
         }
-        let referenceProjection = projection(
-            account: account,
-            window: window,
-            rate: forecast.historicalPercentPerDay,
-            remainingAtReset: forecast.historicalRemainingAtReset
-        )
-        let reference = forecast.historicalReferenceSource.map {
+        let strictAccountReference = forecast.historicalReference?.source
+            == .accountHistory
+            ? forecast.historicalReference
+            : nil
+        let chartReference = strictAccountReference
+            ?? chartHistoricalReference(
+                samples: samples,
+                excluding: window.resetsAt,
+                remaining: window.remainingPercent,
+                daysLeft: max(
+                    window.resetsAt.timeIntervalSince(account.fetchedAt)
+                        / 86_400,
+                    0
+                )
+            )
+            ?? forecast.historicalReference
+        let reference = chartReference.map {
             UsageChartReferenceSeries(
-                source: $0,
-                points: referenceProjection
+                source: $0.source,
+                points: projection(
+                    account: account,
+                    window: window,
+                    rate: $0.percentPerDay,
+                    remainingAtReset: $0.remainingAtReset
+                )
             )
         }
-        let referenceDescription = forecast.historicalReferenceSource.map {
-            " and the \($0.rawValue.lowercased()) leaves \(Int(forecast.historicalRemainingAtReset.rounded())) percent"
+        let referenceDescription = chartReference.map {
+            " and the \($0.source.rawValue.lowercased()) leaves \(Int($0.remainingAtReset.rounded())) percent"
         } ?? ""
         return UsageChartSnapshot(
             observedSource: .account,
@@ -1016,9 +1039,64 @@ enum UsageIntelligenceEngine {
             reference: reference,
             currentAllowanceReset: window.resetsAt,
             allowanceWindows: allowanceWindows,
-            currentRunsFaster: forecast.currentPercentPerDay
-                > forecast.historicalPercentPerDay,
+            currentRunsFaster: chartReference.map {
+                forecast.currentPercentPerDay > $0.percentPerDay
+            } ?? false,
             accessibilityValue: "Now has \(Int(window.remainingPercent.rounded())) percent remaining. At reset, the current pace leaves \(Int(forecast.expectedRemainingAtReset.rounded())) percent\(referenceDescription)."
+        )
+    }
+
+    private static func chartHistoricalReference(
+        samples: [UsageSample],
+        excluding currentReset: Date,
+        remaining: Double,
+        daysLeft: Double
+    ) -> UsageForecastReference? {
+        let day: TimeInterval = 86_400
+        let minimumSpan: TimeInterval = 6 * 3_600
+        let rates = Dictionary(
+            grouping: samples.filter { $0.resetsAt != currentReset },
+            by: \.resetsAt
+        )
+        .compactMap { reset, windowSamples -> (Date, Double)? in
+            let startsAt = reset.addingTimeInterval(
+                -Double(UsageHistoryPolicy.weeklyDurationMinutes) * 60
+            )
+            let segment = UsageHistoryPolicy.segments(
+                windowSamples.filter {
+                    $0.observedAt >= startsAt && $0.observedAt <= reset
+                }
+            ).last ?? []
+            guard let first = segment.first,
+                  let last = segment.last,
+                  segment.count >= 2,
+                  last.observedAt.timeIntervalSince(first.observedAt)
+                    >= minimumSpan,
+                  zip(segment, segment.dropFirst()).allSatisfy({
+                      $1.observedAt.timeIntervalSince($0.observedAt)
+                          <= UsageHistoryPolicy.maximumComparableGap
+                  }) else {
+                return nil
+            }
+            let elapsed = last.observedAt.timeIntervalSince(first.observedAt)
+                / day
+            return (
+                reset,
+                max(
+                    (first.remainingPercent - last.remainingPercent) / elapsed,
+                    0
+                )
+            )
+        }
+        .sorted { $0.0 > $1.0 }
+        .prefix(4)
+        .map(\.1)
+        guard !rates.isEmpty else { return nil }
+        let rate = ForecastEngine.median(Array(rates))
+        return UsageForecastReference(
+            source: .accountHistory,
+            percentPerDay: rate,
+            remainingAtReset: max(remaining - rate * daysLeft, 0)
         )
     }
 

--- a/Tests/CodexLimitsTests/UsageIntelligenceEngineTests.swift
+++ b/Tests/CodexLimitsTests/UsageIntelligenceEngineTests.swift
@@ -922,6 +922,8 @@ final class UsageIntelligenceEngineTests: XCTestCase {
         XCTAssertEqual(reader.evidence.coverage, .low)
         XCTAssertEqual(reader.evidence.confidence, .low)
         XCTAssertNil(reader.guidance)
+        XCTAssertTrue(reader.chart.currentProjection.isEmpty)
+        XCTAssertTrue(reader.chart.historicalProjection.isEmpty)
         XCTAssertEqual(reader.guidanceTitle, "Not enough data")
         XCTAssertEqual(
             reader.guidanceMessage,
@@ -975,6 +977,126 @@ final class UsageIntelligenceEngineTests: XCTestCase {
         XCTAssertEqual(reader.evidence.confidence, .low)
         XCTAssertEqual(reader.evidence.reason, "Less than half of this weekly window is observed")
         XCTAssertNil(reader.guidance)
+        XCTAssertFalse(reader.chart.currentProjection.isEmpty)
+    }
+
+    func testLowCoverageChartStillShowsCurrentAndPastEstimates() {
+        let now = Date(timeIntervalSince1970: 5_600_000)
+        let day: TimeInterval = 86_400
+        let account = makeSnapshot(
+            remaining: 55,
+            fetchedAt: now,
+            tokenHistory: (-33 ... -6).map {
+                TokenDay(
+                    date: now.addingTimeInterval(Double($0) * day),
+                    tokens: 200
+                )
+            } + (-5 ... -1).map {
+                TokenDay(
+                    date: now.addingTimeInterval(Double($0) * day),
+                    tokens: 100
+                )
+            }
+        )
+        let currentWindow = account.mainLimit!.window
+        let previousReset = currentWindow.startsAt
+        let history = weeklySamples(
+            start: previousReset.addingTimeInterval(-5 * day),
+            end: previousReset.addingTimeInterval(-3 * day),
+            reset: previousReset,
+            startRemaining: 80,
+            endRemaining: 40,
+            startTokens: 1_000,
+            endTokens: 2_000
+        )
+        let recent = stride(from: 60, through: 10, by: -10).map { minutesAgo in
+            UsageSample(
+                observedAt: now.addingTimeInterval(-Double(minutesAgo) * 60),
+                remainingPercent: 55,
+                resetsAt: currentWindow.resetsAt
+            )
+        }
+
+        let reader = UsageIntelligenceEngine.evaluate(
+            UsageIntelligenceInput(
+                account: account,
+                samples: history + recent,
+                safetyBuffer: 3,
+                sourceState: .available,
+                now: now,
+                previousStatus: nil
+            )
+        )
+
+        XCTAssertEqual(reader.evidence.confidence, .low)
+        XCTAssertNil(reader.guidance)
+        XCTAssertEqual(reader.chart.currentProjection.count, 2)
+        XCTAssertEqual(reader.chart.historicalProjection.count, 2)
+        XCTAssertTrue(reader.chart.estimatedBackfill.isEmpty)
+        XCTAssertEqual(
+            reader.chart.historicalProjection.last?.remaining ?? .nan,
+            15,
+            accuracy: 0.000_001
+        )
+    }
+
+    func testOutOfWindowHistoryDoesNotCreatePastEstimate() {
+        let now = Date(timeIntervalSince1970: 5_700_000)
+        let account = makeSnapshot(remaining: 55, fetchedAt: now)
+        let priorReset = account.mainLimit!.window.startsAt
+        let stale = weeklySamples(
+            start: priorReset.addingTimeInterval(-9 * 86_400),
+            end: priorReset.addingTimeInterval(-8 * 86_400),
+            reset: priorReset,
+            startRemaining: 80,
+            endRemaining: 40,
+            startTokens: 1_000,
+            endTokens: 2_000
+        )
+
+        let reader = UsageIntelligenceEngine.evaluate(
+            UsageIntelligenceInput(
+                account: account,
+                samples: stale,
+                safetyBuffer: 3,
+                sourceState: .available,
+                now: now,
+                previousStatus: nil
+            )
+        )
+
+        XCTAssertTrue(reader.chart.historicalProjection.isEmpty)
+    }
+
+    func testSparseHistoryDoesNotCreatePastEstimate() {
+        let now = Date(timeIntervalSince1970: 5_800_000)
+        let account = makeSnapshot(remaining: 55, fetchedAt: now)
+        let priorReset = account.mainLimit!.window.startsAt
+        let sparse = [
+            UsageSample(
+                observedAt: priorReset.addingTimeInterval(-2 * 86_400),
+                remainingPercent: 80,
+                resetsAt: priorReset
+            ),
+            UsageSample(
+                observedAt: priorReset.addingTimeInterval(-2 * 86_400 + 6 * 3_600),
+                remainingPercent: 40,
+                resetsAt: priorReset
+            )
+        ]
+
+        let reader = UsageIntelligenceEngine.evaluate(
+            UsageIntelligenceInput(
+                account: account,
+                samples: sparse,
+                safetyBuffer: 3,
+                sourceState: .available,
+                now: now,
+                previousStatus: nil
+            )
+        )
+
+        XCTAssertTrue(reader.chart.historicalProjection.isEmpty)
     }
 
     func testTokenBucketsNeverBecomeObservedAllowancePoints() {
@@ -1395,6 +1517,8 @@ final class UsageIntelligenceEngineTests: XCTestCase {
         XCTAssertEqual(unavailable.freshness, .unavailable)
         XCTAssertEqual(ended.evidence.coverage, .notApplicable)
         XCTAssertEqual(ended.evidence.confidence, .unavailable)
+        XCTAssertTrue(ended.chart.currentProjection.isEmpty)
+        XCTAssertTrue(ended.chart.historicalProjection.isEmpty)
     }
 
     func testQuietDenseHistoryLeavesRoomToUseMore() {


### PR DESCRIPTION
Closes #31

## What changed
- keep the current estimate visible when fresh account points show a useful direction
- use complete account history first, then a dense reset-aware account-history fallback for the chart
- keep low-confidence chart lines out of guidance, status, runway, and Insights
- label the past line as Account history

## Checks
- 424 Swift tests passed
- full-screen UI check passed with Current estimate and Past estimate visible