### PR TITLE
Keep Token activity inside the selected range

### DIFF
--- a/Resources/Info.plist
+++ b/Resources/Info.plist
@@ -13,9 +13,9 @@
     <key>CFBundlePackageType</key>
     <string>APPL</string>
     <key>CFBundleShortVersionString</key>
-    <string>0.2.4</string>
+    <string>0.2.5</string>
     <key>CFBundleVersion</key>
-    <string>5</string>
+    <string>6</string>
     <key>LSApplicationCategoryType</key>
     <string>public.app-category.developer-tools</string>
     <key>LSMinimumSystemVersion</key>

--- a/Sources/CodexLimits/AnalyticsWorkspace.swift
+++ b/Sources/CodexLimits/AnalyticsWorkspace.swift
@@ -82,8 +82,8 @@ struct AccountTokenActivityRange: Equatable, Sendable {
         let day: TimeInterval = 86_400
         self.days = days
             .filter {
-                $0.date < interval.end
-                    && $0.date.addingTimeInterval(day) > interval.start
+                $0.date >= interval.start
+                    && $0.date.addingTimeInterval(day) <= interval.end
             }
             .sorted { $0.date < $1.date }
 

--- a/Sources/CodexLimits/MenuContentView.swift
+++ b/Sources/CodexLimits/MenuContentView.swift
@@ -1601,8 +1601,10 @@ private struct TokenActivityWorkspace: View {
                 if range.days.isEmpty {
                     WorkspaceMessage(
                         icon: "chart.xyaxis.line",
-                        title: "No account token activity",
-                        message: "Codex did not return daily totals for this range."
+                        title: "No complete daily totals",
+                        message: store.state.timeRange == .currentWindow
+                            ? "Choose 4 weeks to see account history."
+                            : "Codex did not return a complete day for this range."
                     ) {
                         EmptyView()
                     }

--- a/Tests/CodexLimitsTests/AnalyticsWorkspaceTests.swift
+++ b/Tests/CodexLimitsTests/AnalyticsWorkspaceTests.swift
@@ -151,7 +151,7 @@ final class AnalyticsWorkspaceTests: XCTestCase {
             interval: interval
         )
 
-        XCTAssertEqual(range.days.count, 4)
+        XCTAssertEqual(range.days.map(\.tokens), [200, 300])
         XCTAssertEqual(range.completeDayCount, 2)
         XCTAssertEqual(range.completeTokens, 500)
 


### PR DESCRIPTION
Closes #43.

## Fix
- chart only daily account buckets fully contained in the selected range
- show a clear empty state when the current window has no complete day
- prepare v0.2.5

## Evidence
- regression test failed with boundary buckets `[100, 200, 300, 400]` instead of `[200, 300]`, then passed after the fix
- 504 Swift tests pass
- full-screen QA passed for Current window and 4 weeks
- production bundle 0.2.5 build 6 passes codesign verification