### PR TITLE
Release Codex Limits 0.2.8

### DIFF
--- a/Resources/Info.plist
+++ b/Resources/Info.plist
@@ -13,9 +13,9 @@
     <key>CFBundlePackageType</key>
     <string>APPL</string>
     <key>CFBundleShortVersionString</key>
-    <string>0.2.7</string>
+    <string>0.2.8</string>
     <key>CFBundleVersion</key>
-    <string>8</string>
+    <string>9</string>
     <key>LSApplicationCategoryType</key>
     <string>public.app-category.developer-tools</string>
     <key>LSMinimumSystemVersion</key>


### PR DESCRIPTION
## Summary
- set app version to 0.2.8
- increment build number to 9

## Verification
- `Scripts/validate-release.sh 0.2.8`
- `swift test` — 565 tests, 0 failures
- production app build
- `codesign --verify --deep --strict`

## Rollback
- previous stable release: `v0.2.7`